### PR TITLE
Conversion of ulids <-> ids on ingress and egress working

### DIFF
--- a/_core/ctlr/_country.ctlr.php
+++ b/_core/ctlr/_country.ctlr.php
@@ -10,5 +10,4 @@ class _country_ctlr extends _ctlr
 	{
 		parent::__construct( '_country' );
 	}
-
 }

--- a/_core/ctlr/_ctlr.ctlr.php
+++ b/_core/ctlr/_ctlr.ctlr.php
@@ -24,6 +24,11 @@ class _ctlr extends _fail
 		$this->_obj( $obj, $args );
 	}
 
+	public function get_table_name()
+	{
+		return $this->obj->get_table_name();
+	}
+
 	/**
 	 * Toggles a row's _active column
 	 *

--- a/_core/ctlr/_perm.ctlr.php
+++ b/_core/ctlr/_perm.ctlr.php
@@ -21,7 +21,7 @@ class _perm_ctlr extends _ctlr
 	 */
 	public function list( array $args = [] ) : array|bool
 	{
-		$perms = $this->obj->get_by_col([ '_perm_role_type' => '!superadmin' ], TRUE, TRUE, [], "_perm_id, _perm_protected, _perm_role_type, _perm_name, _perm_path, _perm_desc" );
+		$perms = $this->obj->get_by_col([ '_perm_role_type' => '!superadmin' ], TRUE, TRUE, [], "_perm_id, _perm_protected, _perm_role_type, _perm_name, _perm_path, _perm_desc, _perm_ulid" );
 		if( FALSE === $perms )
 		{
 			$this->fail( 'perms_not_listed' );

--- a/_core/ctlr/_util.ctlr.php
+++ b/_core/ctlr/_util.ctlr.php
@@ -17,7 +17,7 @@ class _util_ctlr extends _ctlr
 	{
 		// Get all table names
 		// Select all ulid columns for all tables
-		$this->obj->check_for_ulids();
+		print( $this->obj->check_for_ulids() );
 		exit;
 	}
 

--- a/_core/obj/_da.obj.php
+++ b/_core/obj/_da.obj.php
@@ -9,20 +9,22 @@
 
 class _da extends _fail
 {
-	private bool $allow_co_override = FALSE;
-	private bool $paginate = FALSE;
-	private string $dsn = '';
-	protected string $dbuser = '';
-	protected string $dbpass = '';
-	protected string $dbname = '';
-	private int $default_result_count = 0;
-	private int $page = 0;
-	private int $count = 0;
-	protected object|null $db = NULL;
+	private bool $allow_co_override		= FALSE;
+	private bool $paginate				= FALSE;
+	private string $dsn					= '';
+	protected string $dbuser			= '';
+	protected string $dbpass			= '';
+	protected string $dbname			= '';
+	private int $default_result_count	= 0;
+	private int $page					= 0;
+	private int $count					= 0;
+	protected object|null $db			= NULL;
+	public string $last_query			= '';
+	public array $last_bound			= [];
 
 	/**
 	 *	__construct automatically tries to connect to the database using the special $_SERVER vars ($_SERVER[DB*]).
-	 *	For greatest safety, these values should be set in the apache conf and then the web directory should be
+	 *	For greatest safety, these values should be set in the webserver virtualhost conf and then the web directory should be
 	 *	AllowOverride None so that .htaccess files can't change this information.
 	 */
 	public function __construct()

--- a/_core/obj/_obj.obj.php
+++ b/_core/obj/_obj.obj.php
@@ -238,11 +238,12 @@ class _obj extends _da
 		}
 
 		$this->paginate();
+
 		$rows = $this->get_by_col( $select_cols, TRUE, TRUE, $this->data_obj->full_join(), $this->data_obj->select_cols() );
 
 		if( FALSE === $rows )
 		{
-			$this->fail( 'could_not_list_' . $this->table );
+			$this->fail( $this->get_error_msg() );
 			return FALSE;
 		}
 
@@ -521,7 +522,10 @@ class _obj extends _da
 			$cols_and_vals['fk__co_id'] = $this->_co_id;
 		}
 
-		$q .= " AND " . implode( " AND ", array_keys( $params ) );
+		if( $params )
+		{
+			$q .= " AND " . implode( " AND ", array_keys( $params ) );
+		}
 
 		if( $order_by )
 		{
@@ -569,6 +573,7 @@ class _obj extends _da
  		}
  		catch( QueryException $qe )
  		{
+			p( $qe );
 			$this->fail( 'query_failure' );
  			return FALSE;
  		}
@@ -599,6 +604,11 @@ class _obj extends _da
 
 		$this->log_data( $cols )->log_msg( 'get_by_id' );
 		return $this->get_by_col( $cols, FALSE, FALSE, $this->data_obj->full_join(), $this->data_obj->select_cols() );
+	}
+
+	public function get_table_name()
+	{
+		return $this->table;
 	}
 
 	/**

--- a/_core/obj/_public_path.obj.php
+++ b/_core/obj/_public_path.obj.php
@@ -18,12 +18,13 @@ class _public_path extends _obj
 	 * @param string $path full requested path
 	 * @return array|boolean _public_path row or FALSE one rror
 	 */
-	public function is_public_path() : array|bool
+	public function is_public_path( string $requested_path ) : array|bool
 	{
-        list( $ctlr_level, $path ) = explode( '/', _GET['sky_request'] );
+        list( $ctlr_level, $path, $deep_path, $args ) = explode( '/', $requested_path, 4 );
         $path = $ctlr_level . '/' . $path;
+		$deep_path = $deep_path ? $path . '/' . $deep_path : $this->generate_ulid; // Generating a ulid so that the deep path can never be found if there is no deep path
 
-		$public_path = $this->get_by_col([ '_public_path' => [ $ctlr_level, $path, _GET['sky_request'] ] ]);
+		$public_path = $this->get_by_col([ '_public_path' => [ $ctlr_level, $path, $deep_path ] ]);
 		if( FALSE !== $public_path )
 		{
 			$this->log_data([ $path, $public_path ])->log_msg( 'path_is_public' );

--- a/_core/obj/_safe_map.obj.php
+++ b/_core/obj/_safe_map.obj.php
@@ -1,0 +1,215 @@
+<?php
+
+use voku\helper\AntiXSS;
+
+class _safe_map extends _da
+{
+	private mixed $to_sanitize = [];
+	private object $antiXSS;
+
+	public function __construct( mixed $to_sanitize = [] )
+	{
+		parent::__construct();
+		$this->log_chan( '_safe_map' )->log_lvl( 'error' );
+
+		$this->to_sanitize = $to_sanitize;
+		$this->antiXSS = new AntiXSS();
+
+		$this->sanitize_post();
+		$this->sanitize_get();
+	}
+
+	public function sanitize_post() : void
+	{
+		if( $_POST )
+		{
+			$this->log_msg( 'sanitizing POST' );
+			foreach( $_POST as $k => $val )
+			{
+				$_POST[$k] = filter_input( INPUT_POST, $k, FILTER_SANITIZE_SPECIAL_CHARS );
+				$_POST[$k] = $this->antiXSS->xss_clean( $_POST[$k] );
+			}
+		}
+	}
+
+	public function convert_post_ulids()
+	{
+		if( $_POST )
+		{
+			$this->log_msg( 'converting $_POST ULIDs' );
+			$check_keys = [];
+			foreach( $_POST as $key => $val )
+			{
+				switch( $key )
+				{
+					case str_starts_with( $key, 'fk_') :
+						// These should all be foreign keys in Sky
+						$check_keys[$key] = $val;
+						break;
+					case str_ends_with( $key, '_id' ) :
+						// These may or may not be foreign keys, but are going to be gathered to check
+						$check_keys[$key] = $val;
+						break;
+				}
+			}
+
+			if( $check_keys )
+			{
+				// This ensures that even if a column ends in _id but isn't a table id or table ulid, it won't be queried for its corresponding ulid column
+				$query = "SELECT COLUMN_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = '{$_SERVER['DB_NAME']}' AND COLUMN_NAME IN ( " . str_repeat( '?', count( array_keys( $check_keys ) ) ) . " )";
+				$sth = $this->query( $query, array_keys( $check_keys ) );
+				$valid_keys = [];
+				while( $col = $sth->fetch() )
+				{
+					$key = $col['COLUMN_NAME'];
+					if( $check_keys[$key] )
+					{
+						$valid_keys[$key]['value'] = $check_keys[$key];
+						// To get the table name
+						$table = str_replace( '_id', '', $key );
+						$table = str_replace( 'fk_', '', $table );
+						$valid_keys[$key]['table'] = $table;
+					}
+				}
+
+				if( $valid_keys )
+				{
+					foreach( $valid_keys as $col_name => $col )
+					{
+						$table = $col['table'];
+						$val = $col['value'];
+						$query = "SELECT `{$table}_id` AS table_id FROM `{$table}` WHERE `{$table}_ulid` = ?";
+						$sth = $this->query( $query, [ $val ]);
+						$id = $sth->fetch();
+						$_POST[$col_name] = $id['table_id'];
+					}
+				}
+			}
+		}
+	}
+
+	public function sanitize_get() : void
+	{
+		if( $_GET )
+		{
+			$this->log_msg( 'sanitizing GET' );
+			foreach( $_GET as $k => $val )
+			{
+				$_GET[$k] = filter_input( INPUT_GET, $k, FILTER_SANITIZE_SPECIAL_CHARS );
+				$_GET[$k] = $this->antiXSS->xss_clean( $_GET[$k] );
+			}
+		}
+	}
+
+	public function convert_get_ulids( $table, $get_vals = [] )
+	{
+		if( $get_vals )
+		{
+			$this->log_msg( 'converting $_GET ULIDs' );
+			if( !is_array( $get_vals ) )
+			{
+				$get_vals = array( $get_vals );
+			}
+
+			// For gets, since they don't have keys, we need to check all get values for ulid values
+			$new_get = [];
+			foreach( $get_vals as $val )
+			{
+				$query = "SELECT `{$table}_id` AS table_id FROM `{$table}` WHERE `{$table}_ulid` = ?";
+				$sth = $this->query( $query, [ $val ]);
+				$id = $sth->fetch()['table_id'];
+				$new_get[] = $id ? $id : $val;
+			}
+
+			$get_vals = $new_get;
+			if( 1 == count( $get_vals ) )
+			{
+				$get_vals = array_shift( $get_vals );
+			}
+		}
+
+		return $get_vals;
+	}
+
+	public function convert_ids_to_ulids( array|string $data ) : array|string
+	{
+		if( !$data )
+		{
+			return [];
+		}
+
+		if( is_array( $data ) )
+		{
+			foreach( $data as $key => $val )
+			{
+				if( is_array( $val ) )
+				{
+					$data[$key] = $this->replace_id_with_ulid( $val );
+				}
+				else
+				{
+					switch( $key )
+					{
+						case str_starts_with( $key, 'fk_' ):
+							$check_id = str_replace( 'fk_', '', $key );
+							if( $array[$check_id] )
+							{
+								$array[$key] = $array[$check_id];
+								unset( $array[$check_id] );
+							}
+							break;
+						case str_ends_with( $key, '_id' ):
+							$check_ulid = str_replace( '_id', '_ulid', $key );
+							if( $array[$check_ulid] )
+							{
+								$array[$key] = $array[$check_ulid];
+								unset( $array[$check_ulid] );
+							}
+							break;
+					}
+				}
+			}
+
+			return $data;
+		}
+		else
+		{
+			return $data;
+		}
+	}
+
+	private function replace_id_with_ulid( array $array ) : array
+	{
+		foreach( $array as $key => $val )
+		{
+			if( is_array( $val ) )
+			{
+				$array[$key] = $this->replace_id_with_ulid( $val );
+			}
+			else
+			{
+				switch( $key )
+				{
+					case str_starts_with( $key, 'fk_' ):
+						$check_id = str_replace( 'fk_', '', $key );
+						if( $array[$check_id] )
+						{
+							$array[$key] = $array[$check_id];
+							unset( $array[$check_id] );
+						}
+						break;
+					case str_ends_with( $key, '_id' ):
+						$check_ulid = str_replace( '_id', '_ulid', $key );
+						if( $array[$check_ulid] )
+						{
+							$array[$key] = $array[$check_ulid];
+							unset( $array[$check_ulid] );
+						}
+						break;
+				}
+			}
+		}
+
+		return $array;
+	}
+}

--- a/_core/obj/_util.obj.php
+++ b/_core/obj/_util.obj.php
@@ -9,6 +9,14 @@ class _util extends _obj
 
 	public function populate_ulids()
 	{
+		if( defined( 'AUTOPOPULATE_ULIDS' ) && !AUTOPOPULATE_ULIDS )
+		{
+			print( 'AUTOPOPULATE_ULIDS is off' );
+			return FALSE;
+		}
+
+		print ('popping ulids' );
+
 		$table_query = "SELECT TABLE_NAME FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND COLUMN_NAME LIKE '%_ulid'";
 		$table_sth = $this->query( $table_query, [ $this->dbname ]);
 
@@ -27,42 +35,46 @@ class _util extends _obj
 		}
 	}
 
-	public function check_for_ulids() : void
+	public function check_for_ulids() : bool
 	{
-		if( !defined( 'PROTECTED_AGAINST_ACCIDENTAL_RUN') )
+		if( defined( 'AUTOPOPULATE_ULIDS' ) && !AUTOPOPULATE_ULIDS )
 		{
-			exit;
+			print( 'AUTOPOPULATE_ULIDS is off' );
+			return FALSE;
 		}
 
-		$table_query = "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = 'callisto'";
-		$table_sth = $this->query( $table_query );
+		print ('popping ulids' );
+		$table_query = "SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = ?";
+		$table_sth = $this->query( $table_query, [ $_SERVER['DB_NAME'] ] );
 
-		$ulid_query = "SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'callisto' AND TABLE_NAME = ? AND COLUMN_NAME = ?";
+		$ulid_query = "SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?";
 		$ulid_sth = $this->prep( $ulid_query );
 
 		$last_col_query = 
 		"SELECT COLUMN_NAME FROM information_schema.COLUMNS
-		WHERE TABLE_SCHEMA = 'callisto'
+		WHERE TABLE_SCHEMA = ?
 		AND TABLE_NAME = ?
 		AND ORDINAL_POSITION = (
-			SELECT MAX( ORDINAL_POSITION ) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = 'callisto' AND TABLE_NAME = ?
+			SELECT MAX( ORDINAL_POSITION ) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?
 			)";
 		$last_col_sth = $this->prep( $last_col_query );
 
 		while( $table = $table_sth->fetch() )
 		{
-			$ulid_sth->execute([ $table['TABLE_NAME'], $table['TABLE_NAME'] . '_ulid' ]);
+			$ulid_sth->execute([ $_SERVER['DB_NAME'], $table['TABLE_NAME'], $table['TABLE_NAME'] . '_ulid' ]);
 			$has_ulid = $ulid_sth->fetch();
 
 			if( !$has_ulid )
 			{
 				p( $table['TABLE_NAME'] . ' missing ulid' );
-				$last_col_sth->execute([ $table['TABLE_NAME'], $table['TABLE_NAME'] ]);
+				$last_col_sth->execute([ $_SERVER['DB_NAME'], $table['TABLE_NAME'], $_SERVER['DB_NAME'], $table['TABLE_NAME'] ]);
 				$last_col = $last_col_sth->fetch();
 
-				$add_col_q = "ALTER TABLE {$table['TABLE_NAME']} ADD COLUMN {$table['TABLE_NAME']}_ulid CHAR(32) AFTER {$last_col['COLUMN_NAME']}";
+				$add_col_q = "ALTER TABLE `{$table['TABLE_NAME']}` ADD COLUMN `{$table['TABLE_NAME']}_ulid` CHAR(32) AFTER `{$last_col['COLUMN_NAME']}`";
 				$this->query( $add_col_q );
 			}
 		}
+
+		return TRUE;
 	}
 }

--- a/_core/obj/data/_perm_data.obj.php
+++ b/_core/obj/data/_perm_data.obj.php
@@ -27,7 +27,7 @@ class _perm_data extends _obj_data
 			"_perm_name" => "varchar",
 			"_perm_path" => "varchar",
 			"_perm_desc" => "varchar",
-
+			"_perm_ulid" => "char"
 		];
 
 		$this->select_cols = [
@@ -40,7 +40,7 @@ class _perm_data extends _obj_data
 			"_perm_name" => "varchar",
 			"_perm_path" => "varchar",
 			"_perm_desc" => "varchar",
-
+			"_perm_ulid" => "char"
 		];
 
 		$this->full_join = [

--- a/init/lib/002-objects.init.php
+++ b/init/lib/002-objects.init.php
@@ -1,5 +1,6 @@
 <?php
 
+// Reject bad tenant scopes
 $_co = new _co();
 if( !$_co->_co( '_co_id' ) )
 {

--- a/init/lib/003-required_startup.php
+++ b/init/lib/003-required_startup.php
@@ -1,32 +1,9 @@
 <?php
 
-use voku\helper\AntiXSS;
-
-$antiXSS = new AntiXSS();
-
-$_post = [];
-$_get = [];
-
-if( $_POST )
+$autopopulate_ulids = 0;
+if( $_SERVER['IS_DEV'] )
 {
-	$_post = $_POST;
-	foreach( $_post as $k => $val )
-	{
-		$_post[$k] = filter_input( INPUT_POST, $k, FILTER_SANITIZE_SPECIAL_CHARS );
-		$_post[$k] = $antiXSS->xss_clean( $_POST[$k] );
-	}
+	$autopopulate_ulids = 1;
 }
-define( '_POST', $_post );
 
-if( $_GET )
-{
-	$_get = $_GET;
-	foreach( $_get as $k => $val )
-	{
-		$_get[$k] = filter_input( INPUT_GET, $k, FILTER_SANITIZE_SPECIAL_CHARS );
-		$_get[$k] = $antiXSS->xss_clean( $_GET[$k] );
-	}
-}
-define( '_GET', $_get );
-
-unset( $antiXSS );
+define( 'AUTOPOPULATE_ULIDS', $autopopulate_ulids );


### PR DESCRIPTION
Even though ids may be leaked in the array keys of a return object, they will fail to be useful since the conversion to id when passing a ulid into the api will not match a ulid column. Enumeration attacks will fail because of this.