### PR TITLE
_form.send() uses _api to send form data. 

### DIFF
--- a/web/flare/js/_api.flare.js
+++ b/web/flare/js/_api.flare.js
@@ -28,7 +28,14 @@ class _api
 {
     constructor( opts = {} )
     {
-        let defaults = { url: null, method: 'POST', data: {}, force_fetch: true };
+        let defaults = {
+			url: null,
+			method: 'POST',
+			data: {},
+			force_fetch: true,
+			enctype: 'application/json'
+		};
+
         this.opts = { ...defaults, ...opts };
     }
 
@@ -45,21 +52,21 @@ class _api
 				let o_store = new _store();
 				this.opts.auth_token = o_store.fetch( 'auth_token' );
 				
-				let fetchOptions = {
-					method: this.opts.method,
-					headers: {
-						'Content-Type': 'application/json',
-						'auth_token': this.opts.auth_token
-					},
-					body: JSON.stringify( this.opts.data )
-				};
-
 				let beforeRequest = _config.get( '_api', 'beforeRequest' );
 				if( beforeRequest && 'function' == typeof beforeRequest )
 				{
 					beforeRequest( this.opts, fetchOptions );
 				}
 	
+				let fetchOptions = {
+					method: this.opts.method,
+					headers: {
+						'Content-Type': this.opts.enctype,
+						'auth_token': this.opts.auth_token
+					},
+					body: JSON.stringify( this.opts.data )
+				};
+
 				fetch( this.opts.url, fetchOptions )
 				.then(
 					( response ) =>
@@ -78,12 +85,12 @@ class _api
 						{
 							case 200:
 								return response.json();
-							case 403:
-								new _log( 'Invalid path! ' + this.opts.url );
-								return reject( 'Invalid Path' );
 							case 401:
 								new _log( 'Path Unauthorized' );
 								return reject( 'Not Authorized' );
+							case 403:
+								new _log( 'Invalid path! ' + this.opts.url );
+								return reject( 'Invalid Path' );
 							default:
 								return reject( 'Unexpected status: ' + response.status );
 						}

--- a/web/flare/js/_form.flare.js
+++ b/web/flare/js/_form.flare.js
@@ -19,12 +19,13 @@ class _form
 		new _log( '_form constructor' );
 		new _log( _opts );
 
-		let _defaults = { form_id: null, method: 'POST', autoform: false };
+		let _defaults = { form_id: null, autoform: false };
 		this.opts = { ..._defaults, ..._opts };
 
 		new _log( '_form constructor opts' );
 		new _log( this.opts );
-		return this.setup();
+
+		this.setup();
 	}
 
 	autoform()
@@ -308,18 +309,11 @@ class _form
 
 			let o_store = new _store();
 
-			$.ajax({
-				type: this.opts.method,
-				enctype: 'multipart/form-data',
-				url: this.opts.action,
+			new _api({
+				url: this.opts.url,
+				method: this.opts.method,
 				data: _data,
-				headers:
-				{
-					auth_token: o_store.fetch( 'auth_token' )
-				},
-				processData: false,
-				contentType: false,
-				cache: false
+				enctype: 'multipart/form-data',
 			})
 			.then(
 				function( _ret )


### PR DESCRIPTION
Also, _api now accepts enctype in the options object to support sending multipart/form-data.